### PR TITLE
Use \S+, not \w+, so nicks can have hyphens etc.

### DIFF
--- a/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Karma.pm
@@ -37,7 +37,7 @@ sub told {
     my $op_re      = qr{ ( \-\- | \+\+ )        }x;
     my $comment_re = qr{ (?: \s* \# \s* (.+) )? }x;
     for my $regex (
-        qr{^   (\w+)     $op_re $comment_re  }x, # singleword++
+        qr{^   (\S+)     $op_re $comment_re  }x, # singleword++
         qr{^ \( (.+)  \) $op_re $comment_re  }x  # (more words)++
     ) {
         if (my($thing, $op, $comment) = $body =~ $regex) {


### PR DESCRIPTION
Previously, you couldn't give karma to someone with a hyphen in their name.

Thanks to k-man on irc.perl.org/#dancer for bringing this one to my attention :)

This PR in my repo replaces my original PR, eldridge/bot-basicbot-pluggable#20 now I'm taking over maintainership with Mike's kind permission.