### PR TITLE
Various updates, module priorities, readdress and protect feature for infobot

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,6 +17,7 @@ skip = ^Net::Google|Template|Test::Perl::Critic|Test::PerlTidy|Test::Builder::Mo
 [Prereqs]
 Log::Log4perl = 1.11
 Crypt::SaltedHash = 0.06
+MooseX::GetOpt = 0
 
 [Prereqs / TestRequires]
 DBD::SQLite = 0

--- a/lib/App/Bot/BasicBot/Pluggable.pm
+++ b/lib/App/Bot/BasicBot/Pluggable.pm
@@ -50,6 +50,8 @@ has channel => (
 );
 has password => ( is => 'rw', isa => 'Str' );
 has port => ( is => 'rw', isa => 'Int', default => 6667 );
+has useipv6  => ( is => 'rw', isa => 'Bool', default => 1 );
+has localaddr => ( is => 'rw', isa => 'Str' );
 has bot_class =>
   ( is => 'rw', isa => 'Str', default => 'Bot::BasicBot::Pluggable' );
 
@@ -143,6 +145,8 @@ sub _create_bot {
         nick      => $self->nick(),
         charset   => $self->charset(),
         port      => $self->port(),
+        useipv6   => $self->useipv6(),
+        localaddr => $self->localaddr(),
         store     => $self->store(),
         loglevel  => $self->loglevel(),
         logconfig => $self->logconfig(),

--- a/lib/Bot/BasicBot/Pluggable.pm
+++ b/lib/Bot/BasicBot/Pluggable.pm
@@ -176,7 +176,15 @@ sub handler {
 
 sub handlers {
     my $self = shift;
-    my @keys = keys( %{ $self->{handlers} } );
+    my @keys = sort {
+	my $xa = $self->handler($a);
+	my $xb = $self->handler($b);
+	(
+	    ($xb->get('user_priority') || $xb->get('priority') || 0)
+		<=>
+	    ($xa->get('user_priority') || $xa->get('priority') || 0)
+	) || ($a cmp $b)
+    } keys( %{ $self->{handlers} } );
     return @keys if wantarray;
     return \@keys;
 }

--- a/lib/Bot/BasicBot/Pluggable/Module/Infobot.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Infobot.pm
@@ -302,7 +302,9 @@ sub get_raw_factoids {
 
         # it's a deep structure
         $is_are = $raw->{is_are};
-        @factoids = @{ $raw->{factoids} || [] };
+        @factoids = map {
+	    ref $_ && /DBM::Deep::Hash/ ? +{ %$_ } : $_
+	} @{ $raw->{factoids} || [] };
 
     }
     else {

--- a/lib/Bot/BasicBot/Pluggable/Module/Join.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Join.pm
@@ -9,7 +9,7 @@ sub connected {
 
     ## If we are not a array reference, we are problably the old
     ## string format ... trying to convert
-    if ( not ref($channels) eq 'ARRAY' ) {
+    if ( not ref($channels) && $channels =~ 'ARRAY' ) {
         $channels = [ split( /\s+/, $channels ) ];
     }
 
@@ -72,14 +72,14 @@ sub told {
 sub chanjoin {
     my ( $self, $mess ) = @_;
     if ( $mess->{who} eq $self->bot->nick ) {
-        $self->set( channels => $self->bot->channels );
+        $self->set( channels => [ $self->bot->channels ] );
     }
 }
 
 sub chanpart {
     my ( $self, $mess ) = @_;
     if ( $mess->{who} eq $self->bot->nick ) {
-        $self->set( channels => $self->bot->channels );
+        $self->set( channels => [ $self->bot->channels ] );
     }
 }
 

--- a/lib/Bot/BasicBot/Pluggable/Module/Loader.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Loader.pm
@@ -6,7 +6,7 @@ use Try::Tiny;
 
 sub init {
     my $self    = shift;
-    my @modules = $self->store_keys;
+    my @modules = grep !/^user_/, $self->store_keys;
     for (@modules) {
         try { $self->{Bot}->load($_) } catch { warn "Error loading $_: $@." };
     }

--- a/lib/Bot/BasicBot/Pluggable/Module/Vars.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Vars.pm
@@ -21,7 +21,7 @@ sub told {
         my $module = $self->{Bot}->module($mod);
         return "No such module '$module'." unless $module;
         $value = defined($value) ? $value : '';    # wipe if no value.
-        $module->set( "user_$var", $value );
+        $module->set( "user_$var", $value ) if $var;
         return "Set.";
 
     }


### PR DESCRIPTION
Hi there,

I have collected various commits, most of them should also be possible to apply individually. Please discuss if you are interested in taking them

- assorted bug fixes
- fixes when using the DBM::Deep store
- enable IPv6
- a feature to manually order Modules to ensure which ones take priority when catching messages
- a ways to protect facts in the infobot, so they can only be overwritten by authenticated users
- a ways to "ping" another user by having the infobot tell them about a fact, similar to "tell X about Y" but public instead of private message