### PR TITLE
Support private channels which don't leak info

### DIFF
--- a/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
@@ -70,6 +70,16 @@ sub told {
 
     if ( $command eq "seen" and $param =~ /^(\S+)\??$/ ) {
         my $who  = lc($1);
+
+        # First off, if they're asking about themselves, it's easy
+        if ($who eq lc $mess->{who}) {
+            $self->bot->emote(
+                channel => $mess->{channel},
+                body => "hands $who a mirror",
+            );
+            return;
+        }
+
         my $seen = $self->get("seen_$who");
     
         my $ignore_channels = $self->get('user_ignore_channels') || {};

--- a/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
@@ -14,11 +14,13 @@ sub help {
     return
 "Tracks when and where people were last seen. 
 Usage:
-seen <nick>      (find out where 'nick' was last seen)
-hide             (Start hiding yourself from 'seen' reporting)
-unhide           (Stop  hiding yourself from 'seen' reporting)
-hidechan   #chan (Hide a private channel from seen reporting)
-unhidechan #chan (Stop hiding a private channel from seen reporting)
+seen <nick>         (find out where 'nick' was last seen)
+hide                (Start hiding yourself from 'seen' reporting)
+unhide              (Stop  hiding yourself from 'seen' reporting)
+hidechan      #chan (Hide a private channel from seen reporting)
+unhidechan    #chan (Stop hiding a private channel from seen reporting)
+privatechan   #chan (Don't show message contents from #chan in other channels)
+unprivatechan #chan (Show message contents from #chan in other channels)
 ";
 }
 
@@ -80,6 +82,16 @@ sub told {
             return "Sorry, I haven't seen $1.";
         }
 
+        # If the channel is private, and it's a different channel to the one we
+        # are in, hide what they were saying
+        my $private_channels = $self->get('user_private_channels') || {};
+        if (exists $private_channels->{ $seen->{channel} }
+            && $mess->{channel} ne $seen->{channel})
+        {
+            $seen->{what} = "saying something";
+        }
+
+
         my $diff        = time - $seen->{time};
         my $time_string = secs_to_string($diff);
         return
@@ -102,18 +114,24 @@ sub told {
         $self->unset("hide_$nick");
         return "Ok, you're visible to seen status.";
     }
-    elsif ( my ($chanhideaction) = $command =~ /^(hide|unhide)chan$/ ) {
+    elsif ( my ($action, $type) = $command =~ /^((?:un)?hide|private)chan$/ ) {
+        $action = $action ? 'add' : 'remove';
         my $response;
+        my $reply_action = {
+            hide => "tracking users",
+            private => "externally revealing messages from users",
+        }->{$type};
+
         if ($self->authed($mess->{who})) {
-            my $ignore_channels = $self->get('user_ignore_channels') || {};
-            if ($chanhideaction eq 'hide') {
-                $ignore_channels->{$param}++;
-                $response = "OK, not tracking users in $param";
+            my $channels = $self->get('user_' . $type .'_channels') || {};
+            if ($action eq 'add') {
+                $channels->{$param}++;
+                $response = "OK, not $reply_action in $param";
             } else {
-                delete $ignore_channels->{$param};
-                $response =  "OK, tracking users in $param";
+                delete $channels->{$param};
+                $response =  "OK, $reply_action in $param";
             }
-            $self->set('user_ignore_channels', $ignore_channels);
+            $self->set('user_' . $type . '_channels', $channels);
             return $response;
         } else {
             return "You need to be authenticated to do that.";

--- a/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Seen.pm
@@ -114,8 +114,8 @@ sub told {
         $self->unset("hide_$nick");
         return "Ok, you're visible to seen status.";
     }
-    elsif ( my ($action, $type) = $command =~ /^((?:un)?hide|private)chan$/ ) {
-        $action = $action ? 'add' : 'remove';
+    elsif ( my ($action, $type) = $command =~ /^(un)?(hide|private)chan$/ ) {
+        $action = $action ? 'remove' : 'add';
         my $response;
         my $reply_action = {
             hide => "tracking users",


### PR DESCRIPTION
Currently, we can hide a channel entirely from seen reporting, but there was no
way to still be aware that someone had been talking, without their messages in
that channel leaking out into another channel.

This commit adds new "privatechan" / "unprivatechan" commands which mark
channels as "private"; if a seen response is from a private channel, and the
seen request came from a different channel, then the contents of their message
will not be disclosed in the response.

In other words, it's intended for channels we don't need to hide the existence
of, but do need to ensure the contents of discussion in them aren't leaked into
less privileged channels.